### PR TITLE
Export unmounted app as TakeBackMapComponent for import into microsite

### DIFF
--- a/src/TakeBackMapComponent.js
+++ b/src/TakeBackMapComponent.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import './styles/css/index.css';
+import configureStore from './configureStore';
+import AppContainer from './containers/AppContainer';
+
+const store = configureStore();
+
+const TakeBackMapComponent = () => (
+  <MuiThemeProvider>
+    <Provider store={store}>
+      <AppContainer />
+    </Provider>
+  </MuiThemeProvider>
+);
+
+export default TakeBackMapComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,11 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import './styles/css/index.css';
-import configureStore from './configureStore';
-import AppContainer from './containers/AppContainer';
 import registerServiceWorker from './registerServiceWorker';
-
-const store = configureStore();
+import TakeBackMapComponent from './TakeBackMapComponent';
 
 render(
-  <MuiThemeProvider>
-    <Provider store={store}>
-      <AppContainer />
-    </Provider>
-  </MuiThemeProvider>,
+  <TakeBackMapComponent />,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
Using a submodule ended up being way easier than trying to export as a library.  I have heard people express dissatisfaction with submodules, but it seems to work.  And this means we can actually develop on both at the same time, which is a bonus.

I just exported the whole connected, bootstrapped app unmounted, so that the other app can mount it as a component. 

app still works locally
![image](https://user-images.githubusercontent.com/12814449/37859934-248ddb58-2ef2-11e8-895d-6adaf1ae0557.png)
