### PR TITLE
Use Env Keys

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -61,7 +61,7 @@ const Map = controllable(['center', 'zoom', 'hoverKey', 'clickKey'])(
           <GoogleMapReact
             center={this.props.center}
             defaultZoom={this.props.zoom}
-            bootstrapURLKeys={{ key: 'AIzaSyDxJRIxEgWCGd2u-a_ZaucTTO3_DzHHL4U' }}
+            bootstrapURLKeys={{ key: process.env.MAP_KEY || 'AIzaSyDxJRIxEgWCGd2u-a_ZaucTTO3_DzHHL4U' }}
             onChildClick={this.props.onLocationSelect}
             hoverDistance={MARKER_WIDTH / 2}
             onChildMouseEnter={this.onMarkerMouseEnter}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,14 +1,13 @@
 // src/firebase.js
 import firebase from 'firebase';
 const config = {
-  apiKey: 'AIzaSyAGqSVpUm81B-KYs-cyKYq8XnLTbZ8HHJw',
-  authDomain: 'takebackmap.firebaseapp.com',
-  databaseURL: 'https://takebackmap.firebaseio.com',
-  projectId: 'takebackmap',
-  storageBucket: 'takebackmap.appspot.com',
-  messagingSenderId: '257650412128',
+  apiKey: process.env.FIREBASE_API_KEY || 'AIzaSyAGqSVpUm81B-KYs-cyKYq8XnLTbZ8HHJw',
+  authDomain: process.env.FIREBASE_DOMAIN || 'takebackmap.firebaseapp.com',
+  databaseURL: process.env.FIREBASE_DB_URL || 'https://takebackmap.firebaseio.com',
+  projectId: process.env.FIREBASE_ID || 'takebackmap',
+  storageBucket: process.env.FIREBASE_BUCKET || 'takebackmap.appspot.com',
+  messagingSenderId: process.env.FIREBASE_MESSAGE_SENDER_ID || '257650412128',
 };
 
 firebase.initializeApp(config);
 export default firebase;
-


### PR DESCRIPTION
In order to allow the AG's office to use secure keys, and us to continue developing, I left the original keys as defaults, but set the app to look for keys in the env first.  

Things that can now be set through the env:
Firebase config: apiKey, authDomain, databaseURL, projectId, storageBucket, messagingSenderId
BootstrapId in google maps (I assume this is the google maps api key, but I might have grabbed the wrong one)