### PR TITLE
Adding REACT_APP_ to env vars

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,12 +1,12 @@
 // src/firebase.js
 import firebase from 'firebase';
 const config = {
-  apiKey: process.env.FIREBASE_API_KEY || 'AIzaSyAGqSVpUm81B-KYs-cyKYq8XnLTbZ8HHJw',
-  authDomain: process.env.FIREBASE_DOMAIN || 'takebackmap.firebaseapp.com',
-  databaseURL: process.env.FIREBASE_DB_URL || 'https://takebackmap.firebaseio.com',
-  projectId: process.env.FIREBASE_ID || 'takebackmap',
-  storageBucket: process.env.FIREBASE_BUCKET || 'takebackmap.appspot.com',
-  messagingSenderId: process.env.FIREBASE_MESSAGE_SENDER_ID || '257650412128',
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY || 'AIzaSyAGqSVpUm81B-KYs-cyKYq8XnLTbZ8HHJw',
+  authDomain: process.env.REACT_APP_FIREBASE_DOMAIN || 'takebackmap.firebaseapp.com',
+  databaseURL: process.env.REACT_APP_FIREBASE_DB_URL || 'https://takebackmap.firebaseio.com',
+  projectId: process.env.REACT_APP_FIREBASE_ID || 'takebackmap',
+  storageBucket: process.env.REACT_APP_FIREBASE_BUCKET || 'takebackmap.appspot.com',
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGE_SENDER_ID || '257650412128',
 };
 
 firebase.initializeApp(config);


### PR DESCRIPTION
See for explanation:
https://www.linkedin.com/pulse/dockerizing-your-react-app-mike-sparr/
```
Background
React apps bootstrapped with create-react-app include a development server, and preconfigured webpack settings to compile and produce a production deployment. When you deploy your app within Docker, you want the production build version. Unfortunately if you execute the npm run build --production command in your Docker image, then the environment variables you pass to the runtime container are not accessible.

Key challenges and solutions
React apps ignore ENV vars unless prefixed with REACT_APP_<var name>. I believe the only exception may be the NODE_ENV var, but others must be prefixed to be used in your app.
If you build your production app within your image, it will not recognize ENV vars at runtime (unless you pass them as build args during image creation). Because of this, your image should install all necessary dependencies and copy your source files, but your build and server start should be run in a script executed during the CMD step.
```